### PR TITLE
Adding password rotation for MasterDBPassword

### DIFF
--- a/templates/aurora_mysql-master.template.yaml
+++ b/templates/aurora_mysql-master.template.yaml
@@ -1,67 +1,69 @@
+---
 Description: "AWS VPC + Aurora MySql, Do Not Remove Apache License Version 2.0 (qs-) Jun,15,2019"
 Metadata:
   LICENSE: Apache License Version 2.0
   AWS::CloudFormation::Interface:
     ParameterGroups:
-    - Label:
-        default: Network configuration
-      Parameters:
-      - AvailabilityZones
-      - VPCCIDR
-      - PrivateSubnet1CIDR
-      - PrivateSubnet2CIDR
-      - PublicSubnet1CIDR
-      - PublicSubnet2CIDR
-    - Label:
-        default: Linux bastion configuration
-      Parameters:
-       - EnableBastion
-       - KeyPairName
-       - RemoteAccessCIDR
-    - Label:
-        default: Database configuration
-      Parameters:
-      - DBName
-      - DBMasterUsername
-      - DBMasterUserPassword
-      - DBPort
-      - DBAutoMinorVersionUpgrade
-      - DBBackupRetentionPeriod
-      - DBEngineVersion
-      - DBEngineMode
-      - DBMultiAZ
-      - DBInstanceClass
-      - DBMasterUsername
-      - DBMasterUserPassword
-      - DBPort
-      - DBCWLogExports
-      - DBAllocatedStorageEncrypted
-      - NotificationList
-    - Label:
-        default: Severless
-      Parameters:
-        - ServerlessMinCapacityUnit
-    - Label:
-        default: 'Serverless (Applicable only for Database Engine Mode = Serverless)'
-      Parameters:
-        - ServerlessMinCapacityUnit
-        - ServerlessMaxCapacityUnit
-        - ServerlessAutoPause
-        - ServerlessSecondsUntilAutoPause
-    - Label:
-        default: Database tags (optional)
-      Parameters:
-      - EnvironmentStage
-      - Application
-      - ApplicationVersion
-      - ProjectCostCenter
-      - Confidentiality
-      - Compliance
-    - Label:
-        default: Quick Start configuration
-      Parameters:
-      - QSS3BucketName
-      - QSS3KeyPrefix
+      - Label:
+          default: Network configuration
+        Parameters:
+          - AvailabilityZones
+          - VPCCIDR
+          - PrivateSubnet1CIDR
+          - PrivateSubnet2CIDR
+          - PublicSubnet1CIDR
+          - PublicSubnet2CIDR
+      - Label:
+          default: Linux bastion configuration
+        Parameters:
+          - EnableBastion
+          - KeyPairName
+          - RemoteAccessCIDR
+      - Label:
+          default: Database configuration
+        Parameters:
+          - DBName
+          - DBMasterUsername
+          - DBMasterUserPassword
+          - DBPort
+          - DBAutoMinorVersionUpgrade
+          - DBBackupRetentionPeriod
+          - DBEngineVersion
+          - DBEngineMode
+          - DBMultiAZ
+          - DBInstanceClass
+          - DBMasterUsername
+          - DBMasterUserPassword
+          - DBPort
+          - DBCWLogExports
+          - DBAllocatedStorageEncrypted
+          - NotificationList
+          - RotateDBPassword
+      - Label:
+          default: Severless
+        Parameters:
+          - ServerlessMinCapacityUnit
+      - Label:
+          default: 'Serverless (Applicable only for Database Engine Mode = Serverless)'
+        Parameters:
+          - ServerlessMinCapacityUnit
+          - ServerlessMaxCapacityUnit
+          - ServerlessAutoPause
+          - ServerlessSecondsUntilAutoPause
+      - Label:
+          default: Database tags (optional)
+        Parameters:
+          - EnvironmentStage
+          - Application
+          - ApplicationVersion
+          - ProjectCostCenter
+          - Confidentiality
+          - Compliance
+      - Label:
+          default: Quick Start configuration
+        Parameters:
+          - QSS3BucketName
+          - QSS3KeyPrefix
     ParameterLabels:
       AvailabilityZones:
         default: Availability Zones
@@ -132,12 +134,19 @@ Metadata:
       ServerlessSecondsUntilAutoPause:
         default: Pause after time of inactivity
 Parameters:
+  RotateDBPassword:
+    Default: true
+    AllowedValues:
+      - true
+      - false
+    Description: Whether or not to rotate the database password on a schedule.
+    Type: String
   AvailabilityZones:
-   Description: >-
+    Description: >-
       List of Availability Zones to use for the subnets in the VPC. Only two
       Availability Zones are used for this deployment, and the logical order of
       your selections is preserved.
-   Type: 'List<AWS::EC2::AvailabilityZone::Name>'
+    Type: 'List<AWS::EC2::AvailabilityZone::Name>'
   KeyPairName:
     ConstraintDescription: "Name of an existing EC2 key pair."
     Description: Name of an existing public/private key pair, for connecting to your instance.
@@ -219,44 +228,44 @@ Parameters:
     Type: String
     Default: 'Aurora-MySQL5.6.10a'
     AllowedValues:
-    - 'Aurora-MySQL5.6.10a'
-    - 'Aurora-MySQL5.6-1.19.0'
-    - 'Aurora-MySQL5.6-1.19.1'
-    - 'Aurora-MySQL5.6-1.19.2'
-    - 'Aurora-MySQL5.7.12'
-    - 'Aurora-MySQL5.7-2.03.2'
-    - 'Aurora-MySQL5.7-2.03.3'
-    - 'Aurora-MySQL5.7-2.03.4'
-    - 'Aurora-MySQL5.7-2.04.0'
-    - 'Aurora-MySQL5.7-2.04.1'
-    - 'Aurora-MySQL5.7-2.04.1.2'
-    - 'Aurora-MySQL5.7-2.04.2'
-    - 'Aurora-MySQL5.7-2.04.3'
-    - 'Aurora-MySQL5.7-2.04.4'
-    - 'Aurora-MySQL5.7-2.04.5'
+      - 'Aurora-MySQL5.6.10a'
+      - 'Aurora-MySQL5.6-1.19.0'
+      - 'Aurora-MySQL5.6-1.19.1'
+      - 'Aurora-MySQL5.6-1.19.2'
+      - 'Aurora-MySQL5.7.12'
+      - 'Aurora-MySQL5.7-2.03.2'
+      - 'Aurora-MySQL5.7-2.03.3'
+      - 'Aurora-MySQL5.7-2.03.4'
+      - 'Aurora-MySQL5.7-2.04.0'
+      - 'Aurora-MySQL5.7-2.04.1'
+      - 'Aurora-MySQL5.7-2.04.1.2'
+      - 'Aurora-MySQL5.7-2.04.2'
+      - 'Aurora-MySQL5.7-2.04.3'
+      - 'Aurora-MySQL5.7-2.04.4'
+      - 'Aurora-MySQL5.7-2.04.5'
   DBEngineMode:
     Description: The engine mode of the cluster. Currently Aurora Serverless, Global Database and Multi-Master is available for Aurora-MySQL5.6.10a. Aurora Parallel Query is available for Aurora MySQL5.6-x versions.
     Type: String
     Default: 'provisioned'
     AllowedValues:
-    - 'provisioned'
-    - 'parallelquery'
-    - 'serverless'
+      - 'provisioned'
+      - 'parallelquery'
+      - 'serverless'
   DBInstanceClass:
     AllowedValues:
-    - 'global'
-    - 'multimaster'
-    - db.r5.12xlarge
-    - db.r5.4xlarge
-    - db.r5.2xlarge
-    - db.r5.xlarge
-    - db.r5.large
-    - db.r4.16xlarge
-    - db.r4.8xlarge
-    - db.r4.4xlarge
-    - db.r4.2xlarge
-    - db.r4.xlarge
-    - db.r4.large
+      - 'global'
+      - 'multimaster'
+      - db.r5.12xlarge
+      - db.r5.4xlarge
+      - db.r5.2xlarge
+      - db.r5.xlarge
+      - db.r5.large
+      - db.r4.16xlarge
+      - db.r4.8xlarge
+      - db.r4.4xlarge
+      - db.r4.2xlarge
+      - db.r4.xlarge
+      - db.r4.large
     ConstraintDescription: "Must select a valid database instance type."
     Default: db.r4.large
     Description: "The name of the compute and memory capacity class of the database instance. Not Applicable for Aurora Serverless. Supported instance types for Aurora Multi-Master is db.r4.[2/4/8]xlarge only currently."
@@ -356,36 +365,36 @@ Parameters:
     Type: String
     Default: '2'
     AllowedValues:
-    - '1'
-    - '2'
-    - '4'
-    - '8'
-    - '16'
-    - '32'
-    - '64'
-    - '128'
-    - '256'
+      - '1'
+      - '2'
+      - '4'
+      - '8'
+      - '16'
+      - '32'
+      - '64'
+      - '128'
+      - '256'
   ServerlessMaxCapacityUnit:
     Description: The maximum capacity for an Aurora DB cluster in serverless DB engine mode. The maximum capacity must be greater than or equal to the minimum capacity.
     Type: String
     Default: '64'
     AllowedValues:
-    - '1'
-    - '2'
-    - '4'
-    - '8'
-    - '16'
-    - '32'
-    - '64'
-    - '128'
-    - '256'
+      - '1'
+      - '2'
+      - '4'
+      - '8'
+      - '16'
+      - '32'
+      - '64'
+      - '128'
+      - '256'
   ServerlessAutoPause:
     Description: Specifies whether to allow or disallow automatic pause for an Aurora DB cluster in serverless DB engine mode. A DB cluster can be paused only when its idle (it has no connections).
     Type: String
     Default: 'false'
     AllowedValues:
-    - 'true'
-    - 'false'
+      - 'true'
+      - 'false'
   ServerlessSecondsUntilAutoPause:
     Description: The time, in seconds, before an Aurora DB cluster in serverless mode is auto paused. Min = 300, Max = 86400 (24hrs)
     Type: Number
@@ -393,6 +402,10 @@ Parameters:
     MaxValue: 86400
     MinValue: 300
 Conditions:
+  DBPasswordRotation:
+    !Equals
+    - !Ref RotateDBPassword
+    - 'true'
   GovCloudCondition: !Equals
     - !Ref 'AWS::Region'
     - us-gov-west-1
@@ -406,7 +419,7 @@ Resources:
       TemplateURL: !Sub
         - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-aws-vpc/templates/aws-vpc.template
         - QSS3Region:
-            Fn::If:
+            !If
             - GovCloudCondition
             - s3-us-gov-west-1
             - s3
@@ -426,18 +439,18 @@ Resources:
     Properties:
       TemplateURL: !Sub
         - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}templates/aurora_mysql.template.yaml
-        - QSS3Region: !If [GovCloudCondition , s3-us-gov-west-1 , s3]
+        - QSS3Region: !If [GovCloudCondition, s3-us-gov-west-1, s3]
       Parameters:
         Subnet1ID:
-          Fn::GetAtt:
+          !GetAtt
           - VPCStack
           - Outputs.PrivateSubnet1AID
         Subnet2ID:
-          Fn::GetAtt:
+          !GetAtt
           - VPCStack
           - Outputs.PrivateSubnet2AID
         VPCID:
-          Fn::GetAtt:
+          !GetAtt
           - VPCStack
           - Outputs.VPCID
         DBName: !Ref DBName
@@ -448,7 +461,11 @@ Resources:
         DBEngineMode: !Ref DBEngineMode
         DBInstanceClass: !Ref DBInstanceClass
         DBMasterUsername: !Ref DBMasterUsername
-        DBMasterUserPassword: !Ref DBMasterUserPassword
+        DBMasterUserPassword:
+          !If
+          - RotateDBPassword
+          - !Ref DBMasterUserPassword
+          - !Ref AWS::NoValue
         DBPort: !Ref DBPort
         DBMultiAZ: !Ref DBMultiAZ
         DBAccessCIDR: !Ref VPCCIDR
@@ -463,13 +480,16 @@ Resources:
         ServerlessMaxCapacityUnit: !Ref ServerlessMaxCapacityUnit
         ServerlessAutoPause: !Ref ServerlessAutoPause
         ServerlessSecondsUntilAutoPause: !Ref ServerlessSecondsUntilAutoPause
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3KeyPrefix: !Ref QSS3KeyPrefix
+        RotateDBPassword: !Ref RotateDBPassword
   BastionStack:
     Condition: EnableBastionAccess
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       TemplateURL: !Sub
         - https://${QSS3BucketName}.${QSS3Region}.amazonaws.com/${QSS3KeyPrefix}submodules/quickstart-linux-bastion/templates/linux-bastion.template
-        - QSS3Region: !If [GovCloudCondition , s3-us-gov-west-1 , s3]
+        - QSS3Region: !If [GovCloudCondition, s3-us-gov-west-1, s3]
       Parameters:
         KeyPairName: !Ref KeyPairName
         PublicSubnet1ID: !GetAtt
@@ -482,3 +502,16 @@ Resources:
         VPCID: !GetAtt
           - VPCStack
           - Outputs.VPCID
+Rules:
+  GeneratePassword:
+    RuleCondition:
+      !Equals [!Ref RotateDBPassword, true]
+    Assertions:
+      - Assert: !Equals [!Ref DBMasterUserPassword, '']
+        AssertDescription: "Database Passwords are generated when RotateDBPassword is true; Do not provide a password value"
+  ProvidedPassword:
+    RuleCondition:
+      !Equals [!Ref RotateDBPassword, false]
+    Assertions:
+      - Assert: !Not [!Equals [!Ref DBMasterUserPassword, '']]
+        AssertDescription: "Please provide a database password when RotateDBPassword is false."

--- a/templates/aurora_mysql.template.yaml
+++ b/templates/aurora_mysql.template.yaml
@@ -44,6 +44,11 @@ Metadata:
           - ProjectCostCenter
           - Confidentiality
           - Compliance
+      - Label:
+          default: Quick Start configuration
+        Parameters:
+          - QSS3BucketName
+          - QSS3KeyPrefix
     ParameterLabels:
       DBName:
         default: Database name
@@ -76,7 +81,7 @@ Metadata:
       VPCID:
         default: VPC ID
       CustomDBSecurityGroup:
-        default: Custom securiy group ID
+        default: Custom security group ID
       NotificationList:
         default: SNS notification email
       EnvironmentStage:
@@ -99,6 +104,10 @@ Metadata:
         default: Pause compute capacity
       ServerlessSecondsUntilAutoPause:
         default: Pause after time of inactivity
+      QSS3BucketName:
+        default: Quick Start S3 bucket name
+      QSS3KeyPrefix:
+        default: Quick Start S3 key prefix
 Mappings:
   DBFamilyMap:
     "Aurora-MySQL5.6.10a":
@@ -190,6 +199,10 @@ Mappings:
     "Aurora-MySQL5.7-2.04.5":
       "enginename": "aurora-mysql"
 Conditions:
+  DBPasswordRotation:
+    !Equals
+    - !Ref RotateDBPassword
+    - 'true'
   IsServerlessEnabled:
     !Equals
     - !Ref DBEngineMode
@@ -289,6 +302,18 @@ Outputs:
     Description: The alias of the encryption key created for RDS
     Value: !Ref EncryptionKeyAlias
 Parameters:
+  QSS3BucketName:
+    AllowedPattern: "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$"
+    ConstraintDescription: "Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
+    Default: aws-quickstart
+    Description: "S3 bucket name for the Quick Start assets. Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-)."
+    Type: String
+  QSS3KeyPrefix:
+    AllowedPattern: "^[0-9a-zA-Z-/]*$"
+    ConstraintDescription: "Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)."
+    Default: quickstart-amazon-aurora-mysql/
+    Description: "S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/)."
+    Type: String
   DBMultiAZ:
     AllowedValues:
       - "true"
@@ -302,6 +327,13 @@ Parameters:
       - true
       - false
     Description: Whether or not to encrypt the database.
+    Type: String
+  RotateDBPassword:
+    Default: true
+    AllowedValues:
+      - true
+      - false
+    Description: Whether or not to rotate the database password on a schedule.
     Type: String
   DBAutoMinorVersionUpgrade:
     AllowedValues:
@@ -379,6 +411,7 @@ Parameters:
     MinLength: "8"
     NoEcho: "True"
     Type: String
+    Default: ''
   DBMasterUsername:
     AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
     ConstraintDescription: "Must begin with a letter and contain only alphanumeric characters."
@@ -720,7 +753,11 @@ Resources:
           SecondsUntilAutoPause: !Ref ServerlessSecondsUntilAutoPause
         - !Ref AWS::NoValue
       KmsKeyId: !If [UseDatabaseEncryption, !GetAtt EncryptionKey.Arn, !Ref 'AWS::NoValue']
-      MasterUserPassword: !Ref DBMasterUserPassword
+      MasterUserPassword:
+        !If
+        - DBPasswordRotation
+        - !Join ['', ['{{resolve:secretsmanager:', !Ref RDSInstanceRotationSecret, '::password}}' ]]
+        - !Ref DBMasterUserPassword
       MasterUsername: !Ref DBMasterUsername
       Port: !Ref DBPort
       StorageEncrypted: !If [UseDatabaseEncryption, !Ref DBAllocatedStorageEncrypted, !Ref 'AWS::NoValue']
@@ -1009,3 +1046,206 @@ Resources:
         - !If [IsDBMultiAZ, !Ref AuroraDB2, !Ref "AWS::NoValue"]
         - !If [IsDBMultiAZButNotMultiMaster, !Ref AuroraDB3, !Ref "AWS::NoValue"]
       SourceType: 'db-instance'
+  RDSInstanceRotationSecret:
+    Condition: DBPasswordRotation
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      GenerateSecretString:
+        SecretStringTemplate: !Sub '{"username": "${DBMasterUsername}"}'
+        GenerateStringKey: "password"
+        PasswordLength: 16
+        ExcludeCharacters: '"@/\'
+  SecretRDSInstanceAttachment:
+    Condition: DBPasswordRotation
+    Type: AWS::SecretsManager::SecretTargetAttachment
+    Properties:
+      SecretId: !Ref RDSInstanceRotationSecret
+      TargetId: !Ref AuroraDBCluster
+      TargetType: AWS::RDS::DBCluster
+  RDSSecretRotationSchedule:
+    Condition: DBPasswordRotation
+    Type: AWS::SecretsManager::RotationSchedule
+    DependsOn: SecretRDSInstanceAttachment
+    Properties:
+      SecretId: !Ref RDSInstanceRotationSecret
+      RotationLambdaARN: !GetAtt RDSRotationLambda.Arn
+      RotationRules:
+        AutomaticallyAfterDays: 89
+  RDSRotationLambda:
+    Condition: DBPasswordRotation
+    Type: AWS::Lambda::Function
+    Properties:
+      Runtime: python2.7
+      Role: !GetAtt LambdaExecutionRole.Arn
+      Handler: lambda_function.lambda_handler
+      Description: 'This is a lambda to rotate MySql user passwd'
+      FunctionName: 'cfn-rotation-lambda'
+      Environment:
+        Variables:
+          SECRETS_MANAGER_ENDPOINT: !Sub 'https://secretsmanager.${AWS::Region}.amazonaws.com'
+      VpcConfig:
+        SecurityGroupIds:
+          !If
+          - CreateSecurityGroup
+          - !Ref RDSSecurityGroup
+          - !Ref CustomDBSecurityGroup
+        SubnetIds:
+          - !Ref Subnet1ID
+          - !Ref Subnet2ID
+      Code:
+        S3Bucket: !Ref 'LambdaZipsBucket'
+        S3Key: !Sub '${QSS3KeyPrefix}functions/packages/SSMRotate/lambda.zip'
+      Timeout: 300
+  LambdaZipsBucket:
+    Condition: DBPasswordRotation
+    Type: AWS::S3::Bucket
+    Properties:
+      Tags: []
+  CopyZips:
+    Condition: DBPasswordRotation
+    Type: Custom::CopyZips
+    Properties:
+      ServiceToken: !GetAtt 'CopyZipsFunction.Arn'
+      DestBucket: !Ref 'LambdaZipsBucket'
+      SourceBucket: !Ref 'QSS3BucketName'
+      Prefix: !Ref 'QSS3KeyPrefix'
+      Objects:
+        - functions/packages/SSMRotateLambda/lambda.zip
+  LambdaExecutionRole:
+    Condition: DBPasswordRotation
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: lambda_policy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource: arn:aws:logs:*:*:*
+              - Effect: Allow
+                Action:
+                  - cloudformation:DescribeStacks
+                Resource: '*'
+  CopyZipsFunction:
+    Condition: DBPasswordRotation
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: Copies objects from a source S3 bucket to a destination
+      Handler: index.handler
+      Runtime: python2.7
+      Role: !GetAtt 'CopyZipsRole.Arn'
+      Timeout: 240
+      Code:
+        ZipFile: |
+          import json
+          import logging
+          import threading
+          import boto3
+          import cfnresponse
+
+
+          def copy_objects(source_bucket, dest_bucket, prefix, objects):
+              s3 = boto3.client('s3')
+              for o in objects:
+                  key = prefix + o
+                  copy_source = {
+                      'Bucket': source_bucket,
+                      'Key': key
+                  }
+                  print('copy_source: %s' % copy_source)
+                  print('dest_bucket = %s'%dest_bucket)
+                  print('key = %s' %key)
+                  s3.copy_object(CopySource=copy_source, Bucket=dest_bucket,
+                        Key=key)
+
+
+          def delete_objects(bucket, prefix, objects):
+              s3 = boto3.client('s3')
+              objects = {'Objects': [{'Key': prefix + o} for o in objects]}
+              s3.delete_objects(Bucket=bucket, Delete=objects)
+
+
+          def timeout(event, context):
+              logging.error('Execution is about to time out, sending failure response to CloudFormation')
+              cfnresponse.send(event, context, cfnresponse.FAILED, {}, None)
+
+
+          def handler(event, context):
+              # make sure we send a failure to CloudFormation if the function
+              # is going to timeout
+              timer = threading.Timer((context.get_remaining_time_in_millis()
+                        / 1000.00) - 0.5, timeout, args=[event, context])
+              timer.start()
+
+              print('Received event: %s' % json.dumps(event))
+              status = cfnresponse.SUCCESS
+              try:
+                  source_bucket = event['ResourceProperties']['SourceBucket']
+                  dest_bucket = event['ResourceProperties']['DestBucket']
+                  prefix = event['ResourceProperties']['Prefix']
+                  objects = event['ResourceProperties']['Objects']
+                  if event['RequestType'] == 'Delete':
+                      delete_objects(dest_bucket, prefix, objects)
+                  else:
+                      copy_objects(source_bucket, dest_bucket, prefix, objects)
+              except Exception as e:
+                  logging.error('Exception: %s' % e, exc_info=True)
+                  status = cfnresponse.FAILED
+              finally:
+                  timer.cancel()
+                  cfnresponse.send(event, context, status, {}, None)
+  CopyZipsRole:
+    Condition: DBPasswordRotation
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Path: /
+      Policies:
+        - PolicyName: lambda-copier
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - !Sub 'arn:aws:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*'
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:DeleteObject
+                Resource:
+                  - !Sub 'arn:aws:s3:::${LambdaZipsBucket}/${QSS3KeyPrefix}*'
+Rules:
+  GeneratePassword:
+    RuleCondition: !Equals [DBPasswordRotation, true]
+    Assertions:
+      - Assert: !Equals [!Ref DBMasterUserPassword, '']
+        AssertDescription: "Database Passwords are generated when RotateDBPassword is true; Do not provide a password value"
+  ProvidedPassword:
+    RuleCondition: !Equals [DBPasswordRotation, false]
+    Assertions:
+      - Assert: !Not [!Equals [!Ref DBMasterUserPassword, '']]
+        AssertDescription: "Please provide a database password when RotateDBPassword is false."


### PR DESCRIPTION
This PR adds indentation fixes as well as lambda function/template logic to allow DB password rotation. Functionality is needed to avoid duplication/overlay bootstrapping in a downstream dependency. 

* Indentation
* Adding lambda/logic for DB password rotation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
